### PR TITLE
fix lint warnings

### DIFF
--- a/client_legacy.go
+++ b/client_legacy.go
@@ -8,14 +8,14 @@ import (
 	"strings"
 )
 
-func (self *Client) find_JRD(urls []string) (*jrd.JRD, error) {
+func (self *Client) findJRD(urls []string) (*jrd.JRD, error) {
 	for _, try := range urls {
-		try_obj, err := url.Parse(try)
+		tryObj, err := url.Parse(try)
 		if err != nil {
 			log.Print(err)
 			continue
 		}
-		obj, err := self.fetch_JRD(try_obj)
+		obj, err := self.fetchJRD(tryObj)
 		if err != nil {
 			log.Print(err)
 			continue
@@ -25,7 +25,7 @@ func (self *Client) find_JRD(urls []string) (*jrd.JRD, error) {
 	return nil, errors.New("JRD not found")
 }
 
-// Build a serie of well known host JRD URLs from the domain
+// LegacyHostJRDURLs builds a series of well known host JRD URLs from the domain.
 func (self *Client) LegacyHostJRDURLs(domain string) []string {
 	return []string{
 		// first JRD implementation
@@ -35,7 +35,7 @@ func (self *Client) LegacyHostJRDURLs(domain string) []string {
 	}
 }
 
-// Given a domain, this method gets the host meta JRD data,
+// LegacyGetResourceJRDTemplateURL gets the host meta JRD data for the specified domain,
 // and returns the LRDD resource JRD template URL.
 // It tries all the urls returned by client.LegacyHostJRDURLs.
 func (self *Client) LegacyGetResourceJRDTemplateURL(domain string) (string, error) {
@@ -43,12 +43,12 @@ func (self *Client) LegacyGetResourceJRDTemplateURL(domain string) (string, erro
 
 	urls := self.LegacyHostJRDURLs(domain)
 
-	host_jrd, err := self.find_JRD(urls)
+	hostJRD, err := self.findJRD(urls)
 	if err != nil {
 		return "", err
 	}
 
-	link := host_jrd.GetLinkByRel("lrdd")
+	link := hostJRD.GetLinkByRel("lrdd")
 	if link == nil {
 		return "", errors.New("cannot find the LRDD link in the JRD data")
 	}
@@ -61,7 +61,7 @@ func (self *Client) LegacyGetResourceJRDTemplateURL(domain string) (string, erro
 	return template, nil
 }
 
-// Get the JRD data for this resource.
+// LegacyGetJRD gets the JRD data for this resource.
 // Implement the original WebFinger API, ie: first fetch the Host metadata,
 // find the LRDD link, fetch the resource data and convert the XRD in JRD if necessary.
 func (self *Client) LegacyGetJRD(resource *Resource) (*jrd.JRD, error) {
@@ -73,14 +73,14 @@ func (self *Client) LegacyGetJRD(resource *Resource) (*jrd.JRD, error) {
 
 	log.Printf("template: %s", template)
 
-	jrd_url := strings.Replace(template, "{uri}", url.QueryEscape(resource.AsURIString()), 1)
+	jrdURL := strings.Replace(template, "{uri}", url.QueryEscape(resource.AsURIString()), 1)
 
-	log.Printf("User JRD URL: %s", jrd_url)
+	log.Printf("User JRD URL: %s", jrdURL)
 
-	resource_jrd, err := self.find_JRD([]string{jrd_url})
+	resourceJRD, err := self.findJRD([]string{jrdURL})
 	if err != nil {
 		return nil, err
 	}
 
-	return resource_jrd, nil
+	return resourceJRD, nil
 }

--- a/jrd/parser.go
+++ b/jrd/parser.go
@@ -1,4 +1,4 @@
-// Simple JRD Parser
+// Package jrd provides a simple JRD parser.
 //
 // JRD spec: http://tools.ietf.org/html/rfc6415#appendix-A
 package jrd
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 )
 
+// JRD is a JSON Resource Descriptor, specifying properties and related links
+// for a resource.
 type JRD struct {
 	Subject    string
 	Expires    string
@@ -15,6 +17,7 @@ type JRD struct {
 	Properties map[string]interface{}
 }
 
+// Link is a link to a related resource.
 type Link struct {
 	Rel        string
 	Type       string
@@ -24,7 +27,7 @@ type Link struct {
 	Template   string
 }
 
-// Parse the JRD using json.Unmarshal
+// ParseJRD parses the JRD using json.Unmarshal.
 func ParseJRD(blob []byte) (*JRD, error) {
 	jrd := JRD{}
 	err := json.Unmarshal(blob, &jrd)
@@ -34,7 +37,7 @@ func ParseJRD(blob []byte) (*JRD, error) {
 	return &jrd, nil
 }
 
-// Return the first *Link with rel=rel
+// GetLinkByRel returns the first *Link with the specified rel value.
 func (self *JRD) GetLinkByRel(rel string) *Link {
 	for _, link := range self.Links {
 		if link.Rel == rel {

--- a/xrd/parser.go
+++ b/xrd/parser.go
@@ -1,4 +1,4 @@
-// Simple XRD parser
+// Package xrd provides a simple XRD parser.
 //
 // XRD spec: http://docs.oasis-open.org/xri/xrd/v1.0/xrd-1.0.html
 package xrd
@@ -7,6 +7,8 @@ import (
 	"encoding/xml"
 )
 
+// XRD is an Extensible Resource Descriptor, specifying properties and related
+// links for a resource.
 type XRD struct {
 	Subject  string
 	Expires  string
@@ -15,16 +17,19 @@ type XRD struct {
 	Property []Property
 }
 
+// Property is a property of a resource.
 type Property struct {
 	Type  string `xml:"type,attr"`
 	Value string `xml:",chardata"`
 }
 
+// Title is a human-readable description of a Link.
 type Title struct {
 	Lang  string `xml:"lang,attr"`
 	Value string `xml:",chardata"`
 }
 
+// Link is a link to a related resource.
 type Link struct {
 	Rel      string `xml:"rel,attr"`
 	Type     string `xml:"type,attr"`
@@ -34,7 +39,7 @@ type Link struct {
 	Template string `xml:"template,attr"`
 }
 
-// Parse the XRD using xml.Unmarshal
+// ParseXRD parses the XRD using xml.Unmarshal.
 func ParseXRD(blob []byte) (*XRD, error) {
 	parsed := XRD{}
 	err := xml.Unmarshal(blob, &parsed)
@@ -44,7 +49,7 @@ func ParseXRD(blob []byte) (*XRD, error) {
 	return &parsed, nil
 }
 
-// Return the first *Link with rel=rel
+// GetLinkByRel returns the first *Link with the specified rel value.
 func (self *XRD) GetLinkByRel(rel string) *Link {
 	for _, link := range self.Link {
 		if link.Rel == rel {

--- a/xrd/parser_test.go
+++ b/xrd/parser_test.go
@@ -62,24 +62,24 @@ func TestParseXRD(t *testing.T) {
 		t.Error()
 	}
 
-	jrd_obj := obj.ConvertToJRD()
+	jrdObj := obj.ConvertToJRD()
 
-	if jrd_obj.Subject != "http://blog.example.com/article/id/314" {
+	if jrdObj.Subject != "http://blog.example.com/article/id/314" {
 		t.Error()
 	}
-	if jrd_obj.Properties["http://blgx.example.net/ns/version"] != "1.3" {
+	if jrdObj.Properties["http://blgx.example.net/ns/version"] != "1.3" {
 		t.Error()
 	}
-	if jrd_obj.GetLinkByRel("copyright") == nil {
+	if jrdObj.GetLinkByRel("copyright") == nil {
 		t.Error()
 	}
-	if jrd_obj.GetLinkByRel("copyright").Template != "http://example.com/copyright?id={uri}" {
+	if jrdObj.GetLinkByRel("copyright").Template != "http://example.com/copyright?id={uri}" {
 		t.Error()
 	}
-	if jrd_obj.GetLinkByRel("author").Titles["default"] != "About the Author" {
+	if jrdObj.GetLinkByRel("author").Titles["default"] != "About the Author" {
 		t.Error()
 	}
-	if jrd_obj.GetLinkByRel("author").Properties["http://example.com/role"] != "editor" {
+	if jrdObj.GetLinkByRel("author").Properties["http://example.com/role"] != "editor" {
 		t.Error()
 	}
 }

--- a/xrd/to_jrd.go
+++ b/xrd/to_jrd.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ant0ine/go-webfinger/jrd"
 )
 
-// Convert the XRD to JRD
+// ConvertToJRD converts the XRD to JRD.
 func (self *XRD) ConvertToJRD() *jrd.JRD {
 	obj := jrd.JRD{}
 
@@ -13,7 +13,7 @@ func (self *XRD) ConvertToJRD() *jrd.JRD {
 	obj.Aliases = self.Alias
 
 	for _, link := range self.Link {
-		obj.Links = append(obj.Links, _convert_link(&link))
+		obj.Links = append(obj.Links, convertLink(&link))
 	}
 
 	obj.Properties = make(map[string]interface{})
@@ -24,7 +24,7 @@ func (self *XRD) ConvertToJRD() *jrd.JRD {
 	return &obj
 }
 
-func _convert_link(link *Link) jrd.Link {
+func convertLink(link *Link) jrd.Link {
 	obj := jrd.Link{}
 
 	obj.Rel = link.Rel


### PR DESCRIPTION
most of these warnings were related to comments and underscores in function or var names.  This change makes no breaking changes, since none of the named functions were being exported.  All existing tests pass.
